### PR TITLE
timeout needs to be converted into a float

### DIFF
--- a/haste
+++ b/haste
@@ -54,7 +54,7 @@ def create_snippet(data, baseurl, timeout, raw):
     """
     try:
         url = baseurl + "/documents"
-        response = requests.post(url, data.encode('utf-8'), timeout=timeout)
+        response = requests.post(url, data.encode('utf-8'), timeout=float(timeout))
     except Timeout:
         exit("Error: connection timed out")
 


### PR DESCRIPTION
when the timeout is defined in the config file, it comes in as a string, and the latest version of requests expects the timeout to be of type number

please release a new version after this is merged
